### PR TITLE
Make the store/indexer/gateway async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1123,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "tokio",
  "v8",
 ]
 
@@ -1276,8 +1288,10 @@ dependencies = [
 name = "indexer"
 version = "0.1.0"
 dependencies = [
+ "async-recursion",
  "base64 0.21.0",
  "cid",
+ "futures",
  "once_cell",
  "polylang",
  "prost",
@@ -1289,6 +1303,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio",
 ]
 
 [[package]]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
 indexer = { path = "../indexer" }
 polylang = { git = "https://github.com/polybase/polylang", branch = "eng-283-indexer" }
 serde = { version = "1.0", features = ["derive"] }

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -9,6 +9,7 @@ name = "indexer"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio = { version = "1", features = ["full"] }
 base64 = "0.21"
 cid = "0.10"
 once_cell = "1.17.0"
@@ -20,6 +21,8 @@ secp256k1 = { version = "0.26", features = ["rand-std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2"
+async-recursion = "1.0.2"
+futures = "0.3"
 
 [build-dependencies]
 prost-build = "0.11"

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -33,10 +33,10 @@ impl Indexer {
         self.store.destroy()
     }
 
-    pub fn collection(
+    pub async fn collection(
         &self,
         id: String,
     ) -> Result<Collection, Box<dyn Error + Send + Sync + 'static>> {
-        Collection::load(&self.store, id)
+        Collection::load(&self.store, id).await
     }
 }


### PR DESCRIPTION
Runs the RocksDB store functions in tokio's pool of threads where blocking is acceptable, so we won't be blocked by waiting for disk I/O.