### PR TITLE
Separate out IndexValue from RecordValue

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -186,12 +186,12 @@ async fn dereference_fields(
             _ => continue,
         };
 
-        let Some(RecordValue::IndexValue(IndexValue::String(value))) = map.get("id") else {
+        let Some(RecordValue::String(value)) = map.get("id") else {
             return Err(GatewayUserError::CollectionRecordIdNotFound)?;
         };
 
         let collection = if let polylang::stableast::Type::ForeignRecord(fr) = type_ {
-            let Some(RecordValue::IndexValue(IndexValue::String(collection_id))) = map.get("collectionId") else { 
+            let Some(RecordValue::String(collection_id)) = map.get("collectionId") else { 
                 return Err(GatewayUserError::RecordCollectionIdNotFound)?;
             };
 
@@ -361,9 +361,7 @@ async fn has_permission_to_call(
         };
 
         match value {
-            RecordValue::IndexValue(indexer::IndexValue::PublicKey(pk))
-                if pk == auth.public_key() =>
-            {
+            RecordValue::PublicKey(pk) if pk == auth.public_key() => {
                 return Ok(true);
             }
             RecordValue::RecordReference(r) => {
@@ -462,7 +460,7 @@ fn get_collection_ast<'a>(
         return Err(GatewayError::CollectionHasNoAST)?;
     };
 
-    let RecordValue::IndexValue(IndexValue::String(ast_str)) = ast else {
+    let RecordValue::String(ast_str) = ast else {
         return Err(GatewayError::CollectionASTNotString)?;
     };
 
@@ -614,7 +612,7 @@ impl Gateway {
         let Some(output_instance_id) = instance.get("id") else {
             return Err(GatewayUserError::CollectionRecordIdNotFound)?;
         };
-        let RecordValue::IndexValue(IndexValue::String(output_instance_id)) = output_instance_id else {
+        let RecordValue::String(output_instance_id) = output_instance_id else {
             return Err(GatewayUserError::RecordIdNotString)?;
         };
 
@@ -742,7 +740,7 @@ impl Gateway {
                 return Err(GatewayUserError::CollectionRecordIdNotFound)?;
             };
 
-            let RecordValue::IndexValue(IndexValue::String(id)) = id else {
+            let RecordValue::String(id) = id else {
                 return Err(GatewayUserError::RecordIdNotString)?;
             };
 
@@ -1111,17 +1109,10 @@ mod tests {
             .set(
                 "ns/User".to_string(),
                 &[
-                    (
-                        "id".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String(
-                            "ns/User".into(),
-                        )),
-                    ),
+                    ("id".into(), indexer::RecordValue::String("ns/User".into())),
                     (
                         "ast".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String(
-                            serde_json::to_string(&stable_ast).unwrap(),
-                        )),
+                        indexer::RecordValue::String(serde_json::to_string(&stable_ast).unwrap()),
                     ),
                 ]
                 .into(),
@@ -1134,16 +1125,8 @@ mod tests {
             .set(
                 "1".to_string(),
                 &[
-                    (
-                        "id".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String("1".into())),
-                    ),
-                    (
-                        "name".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String(
-                            "John".into(),
-                        )),
-                    ),
+                    ("id".into(), indexer::RecordValue::String("1".into())),
+                    ("name".into(), indexer::RecordValue::String("John".into())),
                 ]
                 .into(),
             )
@@ -1170,14 +1153,8 @@ mod tests {
                 collection_id: "ns/User".to_string(),
                 record_id: "1".to_string(),
                 record: HashMap::from([
-                    (
-                        "id".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String("1".into()))
-                    ),
-                    (
-                        "name".into(),
-                        indexer::RecordValue::IndexValue(indexer::IndexValue::String("Tim".into()))
-                    )
+                    ("id".into(), indexer::RecordValue::String("1".into())),
+                    ("name".into(), indexer::RecordValue::String("Tim".into()))
                 ])
             }
         );

--- a/indexer/src/store.rs
+++ b/indexer/src/store.rs
@@ -184,7 +184,7 @@ pub(crate) mod tests {
             "ns".to_string(),
             &[&["name"]],
             &[keys::Direction::Ascending],
-            vec![Cow::Owned(IndexValue::String("John".to_string()))],
+            vec![Cow::Owned(IndexValue::String("John".to_string().into()))],
         )
         .unwrap();
 

--- a/indexer/src/where_query.rs
+++ b/indexer/src/where_query.rs
@@ -82,10 +82,10 @@ pub(crate) enum WhereValue {
     Boolean(bool),
 }
 
-impl From<WhereValue> for IndexValue {
+impl From<WhereValue> for IndexValue<'_> {
     fn from(value: WhereValue) -> Self {
         match value {
-            WhereValue::String(s) => IndexValue::String(s),
+            WhereValue::String(s) => IndexValue::String(Cow::Owned(s)),
             WhereValue::Number(n) => IndexValue::Number(n),
             WhereValue::Boolean(b) => IndexValue::Boolean(b),
         }
@@ -238,14 +238,14 @@ mod test {
             "namespace".to_string(),
             &[&["name"]],
             &[keys::Direction::Ascending],
-            vec![Cow::Borrowed(&IndexValue::String("john".to_string()))]
+            vec![Cow::Owned(IndexValue::String("john".to_string().into()))]
         )
         .unwrap(),
         keys::Key::new_index(
             "namespace".to_string(),
             &[&["name"]],
             &[keys::Direction::Ascending],
-            vec![Cow::Borrowed(&IndexValue::String("john".to_string()))]
+            vec![Cow::Owned(IndexValue::String("john".to_string().into()))]
         )
         .unwrap()
         .wildcard()
@@ -414,7 +414,7 @@ mod test {
             &[&["name"], &["age"]],
             &[keys::Direction::Ascending, keys::Direction::Ascending],
             vec![
-                Cow::Borrowed(&IndexValue::String("John".to_string())),
+                Cow::Owned(IndexValue::String("John".to_string().into())),
                 Cow::Borrowed(&IndexValue::Number(30.0)),
             ]
         )
@@ -424,7 +424,7 @@ mod test {
             "namespace".to_string(),
             &[&["name"], &["age"]],
             &[keys::Direction::Ascending, keys::Direction::Ascending],
-            vec![Cow::Borrowed(&IndexValue::String("John".into())),]
+            vec![Cow::Owned(IndexValue::String("John".into())),]
         )
         .unwrap()
         .wildcard()
@@ -449,8 +449,8 @@ mod test {
             &[&["name"], &["id"]],
             &[keys::Direction::Ascending, keys::Direction::Ascending],
             vec![
-                Cow::Borrowed(&IndexValue::String("John".to_string())),
-                Cow::Borrowed(&IndexValue::String("rec1".to_string())),
+                Cow::Owned(IndexValue::String("John".to_string().into())),
+                Cow::Owned(IndexValue::String("rec1".to_string().into())),
             ]
         )
         .unwrap(),
@@ -459,8 +459,8 @@ mod test {
             &[&["name"], &["id"]],
             &[keys::Direction::Ascending, keys::Direction::Ascending],
             vec![
-                Cow::Borrowed(&IndexValue::String("John".to_string())),
-                Cow::Borrowed(&IndexValue::String("rec1".to_string())),
+                Cow::Owned(IndexValue::String("John".to_string().into())),
+                Cow::Owned(IndexValue::String("rec1".to_string().into())),
             ]
         )
         .unwrap()

--- a/polybase/src/db.rs
+++ b/polybase/src/db.rs
@@ -274,12 +274,12 @@ impl Db {
             .get("ast")
             .expect("Collection AST not found in collection record");
 
-        let indexer::RecordValue::IndexValue(indexer::IndexValue::String(old_ast)) = old_ast
+        let indexer::RecordValue::String(old_ast) = old_ast
             else {
                 return Err(DbError::CollectionASTInvalid("Collection AST in old record is not a string".into()));
             };
 
-        let indexer::RecordValue::IndexValue(indexer::IndexValue::String(new_ast)) = record
+        let indexer::RecordValue::String(new_ast) = record
                 .get("ast")
                 .expect("Collection AST not found in new collection record") else {
             return Err(DbError::CollectionASTInvalid("Collection AST in new ".into()));


### PR DESCRIPTION
This will make it easier to add new indexable types in the future, without rebuilding the database.