### PR TITLE
Fail on update to Collection/Collection record

### DIFF
--- a/indexer/src/collection.rs
+++ b/indexer/src/collection.rs
@@ -139,7 +139,7 @@ static COLLECTION_COLLECTION_RECORD: Lazy<RecordRoot> = Lazy::new(|| {
 
     hm.insert(
         "id".to_string(),
-        RecordValue::String("collections".to_string()),
+        RecordValue::String("Collection".to_string()),
     );
 
     let code = r#"

--- a/polybase/src/db.rs
+++ b/polybase/src/db.rs
@@ -21,6 +21,9 @@ pub enum DbError {
     #[error("collection AST is invalid: {0}")]
     CollectionASTInvalid(String),
 
+    #[error("cannot update the Collection collection record")]
+    CollectionCollectionRecordUpdate,
+
     #[error(transparent)]
     GatewayError(#[from] gateway::GatewayError),
 
@@ -247,6 +250,10 @@ impl Db {
             } = &change
             {
                 if collection_id == "Collection" {
+                    if record_id == "Collection" {
+                        return Err(DbError::CollectionCollectionRecordUpdate);
+                    }
+
                     self.validate_schema_update(collection_id, record_id, record, auth)
                         .await?;
                 }


### PR DESCRIPTION
Technically it already fails with "collection id is missing namespace", but I think it's worth adding, just to be safe. We could also move this error to the schema function "updateCode"