### PR TITLE
Propagate MissingField error to the user

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -602,9 +602,9 @@ impl Gateway {
         output.instance = reference_records(&collection, &collection_ast, output.instance)?;
         let instance = indexer::json_to_record(&collection_ast, output.instance, false).map_err(
             |e| match e {
-                indexer::RecordError::MissingField { field }
-                    if field == "id" && function_name == "constructor" =>
-                {
+                indexer::RecordError::UserError(indexer::RecordUserError::MissingField {
+                    field,
+                }) if field == "id" && function_name == "constructor" => {
                     GatewayError::UserError(GatewayUserError::ConstructorMustAssignId)
                 }
                 e => GatewayError::IndexerError(IndexerError::from(e)),

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -16,7 +16,7 @@ pub use keys::Direction;
 pub use publickey::PublicKey;
 pub use record::{
     json_to_record, record_to_json, Converter, ForeignRecordReference, IndexValue, PathFinder,
-    RecordError, RecordRoot, RecordValue,
+    RecordError, RecordRoot, RecordUserError, RecordValue,
 };
 pub use stableast_ext::FieldWalker;
 pub use where_query::WhereQuery;

--- a/polybase/src/errors/http.rs
+++ b/polybase/src/errors/http.rs
@@ -137,6 +137,12 @@ impl From<indexer::where_query::WhereQueryUserError> for HTTPError {
     }
 }
 
+impl From<indexer::RecordUserError> for HTTPError {
+    fn from(err: indexer::RecordUserError) -> Self {
+        HTTPError::new(ReasonCode::from_record_error(&err), Some(Box::new(err)))
+    }
+}
+
 impl From<indexer::IndexerError> for HTTPError {
     fn from(err: indexer::IndexerError) -> Self {
         match err {
@@ -148,6 +154,11 @@ impl From<indexer::IndexerError> for HTTPError {
             // WhereQuery
             indexer::IndexerError::WhereQuery(e) => match e {
                 indexer::where_query::WhereQueryError::UserError(e) => e.into(),
+                _ => HTTPError::new(ReasonCode::Internal, Some(Box::new(e))),
+            },
+            // Record
+            indexer::IndexerError::Record(e) => match e {
+                indexer::RecordError::UserError(e) => e.into(),
                 _ => HTTPError::new(ReasonCode::Internal, Some(Box::new(e))),
             },
             // Other errors are internal

--- a/polybase/src/errors/reason.rs
+++ b/polybase/src/errors/reason.rs
@@ -19,6 +19,9 @@ pub enum ReasonCode {
     #[display(fmt = "record/id-modified")]
     RecordIDModified,
 
+    #[display(fmt = "record/missing-field")]
+    RecordMissingField,
+
     #[display(fmt = "index/missing-index")]
     IndexesMissingIndex,
 
@@ -91,6 +94,7 @@ impl ReasonCode {
             ReasonCode::RecordCollectionIdNotFound => ErrorCode::NotFound,
             ReasonCode::RecordFieldNotObject => ErrorCode::InvalidArgument,
             ReasonCode::RecordIDModified => ErrorCode::FailedPrecondition,
+            ReasonCode::RecordMissingField => ErrorCode::InvalidArgument,
             ReasonCode::IndexesMissingIndex => ErrorCode::FailedPrecondition,
             ReasonCode::FunctionInvalidatedId => ErrorCode::FailedPrecondition,
             ReasonCode::FunctionNotFound => ErrorCode::NotFound,
@@ -222,6 +226,12 @@ impl ReasonCode {
             indexer::collection::CollectionUserError::IndexFieldCannotBeBytes { .. } => {
                 ReasonCode::CollectionInvalidSchema
             }
+        }
+    }
+
+    pub fn from_record_error(err: &indexer::RecordUserError) -> Self {
+        match err {
+            indexer::RecordUserError::MissingField { .. } => ReasonCode::RecordMissingField,
         }
     }
 


### PR DESCRIPTION
I set `record/missing-field` (new) as the reason, but another reason that would make sense would be `function/missing-field`.