### PR TITLE
ENG-635 - Invalid field name causes 500 error

### DIFF
--- a/polybase/src/errors/http.rs
+++ b/polybase/src/errors/http.rs
@@ -100,6 +100,7 @@ impl From<db::DbError> for HTTPError {
                 HTTPError::new(ReasonCode::CollectionNotFound, Some(Box::new(err)))
             }
             db::DbError::GatewayError(e) => e.into(),
+            db::DbError::IndexerError(e) => e.into(),
             _ => HTTPError::new(ReasonCode::Internal, Some(Box::new(err))),
         }
     }


### PR DESCRIPTION
Changes made:
   - Updated `errors/http.rs` to handle schema update error.
   - added tests along with helpers.