### PR TITLE
Fix api::start_stop::test_start_stop test

### DIFF
--- a/polybase/tests/api/start_stop.rs
+++ b/polybase/tests/api/start_stop.rs
@@ -1,14 +1,29 @@
+use crate::api::ServerConfig;
+
 #[tokio::test]
 async fn test_start_stop() {
     let api_port;
     {
-        let server = super::Server::setup_and_wait(None).await;
+        let server = super::Server::setup_and_wait(Some(ServerConfig {
+            keep_port_after_drop: true,
+            ..Default::default()
+        }))
+        .await;
         api_port = server.api_port;
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    for i in 0..10 {
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-    reqwest::get(format!("http://localhost:{api_port}/v0/health"))
-        .await
-        .expect_err("Server should be stopped");
+        if reqwest::get(format!("http://localhost:{api_port}/v0/health"))
+            .await
+            .is_ok()
+        {
+            if i == 9 {
+                panic!("Server should be stopped");
+            }
+        } else {
+            break;
+        }
+    }
 }

--- a/polybase/tests/api/whitelist.rs
+++ b/polybase/tests/api/whitelist.rs
@@ -28,7 +28,11 @@ collection Account {
         signature
     });
 
-    let server = Server::setup_and_wait(Some(ServerConfig { whitelist })).await;
+    let server = Server::setup_and_wait(Some(ServerConfig {
+        whitelist,
+        ..Default::default()
+    }))
+    .await;
 
     let res = server
         .create_collection::<Account>("test/Account", schema, Some(&signer))
@@ -62,7 +66,11 @@ collection Account {
         signature
     });
 
-    let server = Server::setup_and_wait(Some(ServerConfig { whitelist })).await;
+    let server = Server::setup_and_wait(Some(ServerConfig {
+        whitelist,
+        ..Default::default()
+    }))
+    .await;
 
     let res = server
         .create_collection::<Account>("test/Account", schema, Some(&signer))
@@ -95,7 +103,11 @@ collection Account {
     let public_key = indexer::PublicKey::from_secp256k1_key(&public_key).unwrap();
     let whitelist = Some(vec![public_key.to_hex().unwrap()]);
 
-    let server = Server::setup_and_wait(Some(ServerConfig { whitelist })).await;
+    let server = Server::setup_and_wait(Some(ServerConfig {
+        whitelist,
+        ..Default::default()
+    }))
+    .await;
 
     let res = server
         .create_collection::<Account>("test/Account", schema, None)


### PR DESCRIPTION
After dropping the server and releasing the port we waited 3s before sending a request to check that the server is down. I think sometimes another test would get the same port in the 3s window and we would send a request to that instance.