### PR TITLE
ENG-902: Metrics data log not formatted correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5459,12 +5459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac98e757a488cc11d6a84a52d223b970e11c99e5158cc2ff07b8544ccc260078"
 dependencies = [
  "Inflector",
+ "http",
  "serde",
  "serde_json",
  "thiserror",
  "time 0.3.21",
  "tracing-core",
  "tracing-subscriber",
+ "url",
+ "valuable",
+ "valuable-serde",
 ]
 
 [[package]]
@@ -5732,6 +5736,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "valuable-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285cfff30cdabe26626736a54d989687dd9cab84f51f4048b61d6d0ae8b0907"
+dependencies = [
+ "serde",
+ "valuable",
 ]
 
 [[package]]

--- a/polybase/Cargo.toml
+++ b/polybase/Cargo.toml
@@ -61,7 +61,7 @@ ed25519-dalek = "1.0.1"
 bs58 = "0.5.0"
 tracing = { version = "0.1.37", features = ["valuable"] }
 tracing-subscriber = {version = "0.3.17", features = ["env-filter", "fmt", "std", "registry", "ansi", "json"] }
-tracing-stackdriver = "0.7.2"
+tracing-stackdriver = { version = "0.7.2", features = [ "valuable" ] }
 valuable = { version = "0.1.0", features = ["derive"] }
 base64 = "0.21"
 


### PR DESCRIPTION
  - Added missed "feature" on the `tracing-stackdriver` crate.

Comment: The feature flag somehow got messed up during the original merge. The `valuable` feature allows the existing code to serialise and deserialise properly. 

Local log output (using `STACK_DRIVER` log format):

```
{
  "time": "2023-06-30T08:10:27.280443Z",
  "target": "polybase::errors::logger",
  "logging.googleapis.com/sourceLocation": {
    "file": "polybase/src/errors/logger.rs",
    "line": "81"
  },
  "severity": "INFO",
  "metricsData": {
    "NumberOfRecordsBeingReturned": {
      "num_records": 47,
      "req_uri": "/v0/collections/Collection/records"
    }
  }
}
```