### PR TITLE
Fix field paths in error messages for UnexpectedFields

### DIFF
--- a/indexer/src/record.rs
+++ b/indexer/src/record.rs
@@ -382,7 +382,9 @@ impl Converter for (&polylang::stableast::Type<'_>, serde_json::Value) {
                 serde_json::Value::Object(mut o) => {
                     let mut map = HashMap::with_capacity(o.len());
 
+                    let path_len_before_loop = path.len();
                     for field in &t.fields {
+                        path.truncate(path_len_before_loop);
                         path.push(Cow::Owned(field.name.to_string()));
 
                         let Some((k, v)) = o.remove_entry(field.name.as_ref()) else {
@@ -399,9 +401,8 @@ impl Converter for (&polylang::stableast::Type<'_>, serde_json::Value) {
                         };
 
                         map.insert(k, Converter::convert((&field.type_, v), path, always_cast)?);
-
-                        path.pop();
                     }
+                    path.truncate(path_len_before_loop);
 
                     if !o.is_empty() && !always_cast {
                         let path = path.join(".");

--- a/polybase/tests/api/nested_field.rs
+++ b/polybase/tests/api/nested_field.rs
@@ -155,7 +155,7 @@ async fn nested_field_extraneous_fields() {
 collection Account {
     id: string;
     info: {
-        name: string;
+        name?: string;
     };
 
     constructor (id: string, info: map<string, string>) {
@@ -172,7 +172,6 @@ collection Account {
     let err = col
         .create(
             json!(["id1", {
-                "name": "John",
                 "surname": "Doe",
                 "age": "30",
             }]),
@@ -183,8 +182,13 @@ collection Account {
 
     assert_eq!(err.error.code, "invalid-argument");
     assert_eq!(err.error.reason, "record/invalid-field");
-    assert!(matches!(
-        err.error.message.as_str(),
-        "unexpected fields: info.age, info.surname" | "unexpected fields: info.surname, info.age"
-    ));
+    assert!(
+        matches!(
+            err.error.message.as_str(),
+            "unexpected fields: info.age, info.surname"
+                | "unexpected fields: info.surname, info.age"
+        ),
+        "{}",
+        err.error.message
+    );
 }


### PR DESCRIPTION
Minor fix. Forgot to actually commit the changes in record.rs that fixed it + the test didn't actually reach the code that causes the error (optional fields, the `continue`).