### PR TITLE
Updating the `Polybase-rust` resolver version to 2 (the new default `Cargo` resolver)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "indexer",
     "indexer_rocksdb",
 ]
+resolver = "2"
 
 [profile.release]
 debug-assertions = true


### PR DESCRIPTION
Changes:
  - updated (virtual) workspace `Cargo` resolver to "2".
  
Rationale and additional information added in Linear.